### PR TITLE
Update AWS CLI if Already Exists

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ USER root
 RUN apt-get update && apt-get install -y git graphviz curl unzip groff uuid-runtime
 
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
-    unzip awscliv2.zip && \
-	./aws/install
+    unzip -qu awscliv2.zip && \
+	./aws/install --update
 
 COPY entrypoint.sh /entrypoint.sh
 COPY dump_dags.py /dump_dags.py


### PR DESCRIPTION
Update AWS CLI if Already Exists. Otherwise, the action will fail when the cli is already installed